### PR TITLE
Change `tkn ERC20.sol`

### DIFF
--- a/tkn ERC20.sol
+++ b/tkn ERC20.sol
@@ -2,31 +2,40 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
 
-contract TKNContract is ERC20 {
+contract TKNContract is ERC20, Ownable, Pausable {
+    uint256 public totalMax = 1000000000 * 1e18;
+    uint256 private currentSupply = 0;
 
-    uint256 public totalMax;
-    uint256 private currentSupply;
-    address public owner;
+    event Minted(address to, uint256 amount);
+    event Burned(address from, uint256 amount);
 
-    modifier onlyOwner() {
-        require(owner == msg.sender, "You are not an owner");
-        _;
+    constructor() ERC20("Test TKN", "TTKN") {
+        transferOwnership(msg.sender);
     }
 
-    constructor() ERC20 ("Test TKN", "TTKN") {
-        totalMax = 1000000000 * 1e18;
-        owner = msg.sender;
-    }
-
-    function mint(uint256 amount) external onlyOwner {
-        currentSupply = totalSupply();
-        require(amount + currentSupply <= totalMax, "Exceeded amount of tokens");
+    function mint(uint256 amount) external onlyOwner whenNotPaused {
+        require(amount > 0, "Amount must be greater than zero");
+        require(currentSupply + amount <= totalMax, "Exceeded max supply");
+        currentSupply += amount;
         _mint(msg.sender, amount);
+        emit Minted(msg.sender, amount); // Log the mint event
     }
 
-    function burn(uint256 amount) external {
+    function burn(uint256 amount) external whenNotPaused {
+        require(amount > 0, "Amount must be greater than zero");
+        currentSupply -= amount;
         _burn(msg.sender, amount);
+        emit Burned(msg.sender, amount); // Log the burn event
     }
 
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
 }


### PR DESCRIPTION
- Change `currentSupply` to a state variable that is updated on each `mint()` and `burn()` call to avoid unnecessary `totalSupply()` calls and potentially reduce gas costs
- Replace custom owner checks with OpenZeppelin's `Ownable` library for improved security and reduced code duplication + support transfering ownership to a new address
- Introduce the ability to pause contract operations using OpenZeppelin’s `Pausable` modifier to handle emergencies or maintenance needs
- Implement events for `mint()` and `burn()` operations to facilitate tracking of token state changes
- Add checks to ensure the amount for `mint()` and `burn()` operations is greater than zero to prevent zero-value transactions and potential logical errors